### PR TITLE
Fixing JSON Serialization and Request Type for Listing Campaign Details API

### DIFF
--- a/client.go
+++ b/client.go
@@ -253,7 +253,7 @@ func (c *Client) ListTemplates(t *TemplateList) (TemplateListResponse, error) {
 	r := bytes.NewReader(body)
 
 	url := fmt.Sprintf("https://api.sendinblue.com/v2.0/campaign/detailsv2")
-	req, err := http.NewRequest("GET", url, r)
+	req, err := http.NewRequest("POST", url, r)
 	if err != nil {
 		err := fmt.Errorf("Could not create http request: %+v", err)
 		return emptyResp, err

--- a/smtp.go
+++ b/smtp.go
@@ -149,8 +149,8 @@ type TemplateResponse struct {
 
 type TemplateListData struct {
 	Campaign_records       []CampaignData `json:"campaign_records"`
-	Page                   int            `json:"page"`
-	Page_limit             int            `json:"page_limit"`
+	Page                   string         `json:"page"`
+	Page_limit             string         `json:"page_limit"`
 	Total_campaign_records int            `json:"total_campaign_records"`
 }
 


### PR DESCRIPTION
Hi,

Thanks for creating and maintaining this library.

While using this library in an implementation, we have found the following errors in the `ListTemplates` method in the `client.go`.

```
{"error":"Could not decode response format: json: cannot unmarshal string into Go struct field TemplateListData.page of type int","level":"fatal","msg":"error while initializing sendinblue email provider","time":"2017-06-02T11:55:37+05:30"}

{"error":"Could not decode response format: json: cannot unmarshal string into Go struct field TemplateListData.page of type int","level":"fatal","msg":"error while initializing sendinblue email provider","time":"2017-06-02T11:55:54+05:30"}

{"error":"Could not send http request: Get https://api.sendinblue.com/v2.0/campaign/detailsv2: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)","level":"fatal","msg":"error while initializing sendinblue email provider","time":"2017-06-02T12:00:14+05:30"}
```
This pull request will be fixing it.