### PR TITLE
Zey send email

### DIFF
--- a/client.go
+++ b/client.go
@@ -418,8 +418,14 @@ func (c *Client) SendTemplateEmail(id int, to []string, e *EmailOptions) (EmailR
 	var response EmailResponse
 	err = json.Unmarshal(b, &response)
 	if err != nil {
-		err := fmt.Errorf("Could not decode response format: %+v", err)
-		return emptyResp, err
+		var responseError EmailResponseError
+		if err = json.Unmarshal(b, &responseError); err != nil {
+			err := fmt.Errorf("Could not decode response format: %+v", err)
+			return emptyResp, err
+		} else {
+			err := fmt.Errorf(responseError.Message)
+			return emptyResp, err
+		}
 	}
 
 	return response, nil

--- a/smtp.go
+++ b/smtp.go
@@ -132,9 +132,9 @@ type EmailData struct {
 }
 
 type EmailResponse struct {
-	Code    string    `json:"code"`
-	Message string    `json:"message"`
-	Data    EmailData `json:"data"`
+	Code    string      `json:"code"`
+	Message string      `json:"message"`
+	Data    []EmailData `json:"data"`
 }
 
 type TemplateData struct {

--- a/smtp.go
+++ b/smtp.go
@@ -132,6 +132,12 @@ type EmailData struct {
 }
 
 type EmailResponse struct {
+	Code    string    `json:"code"`
+	Message string    `json:"message"`
+	Data    EmailData `json:"data"`
+}
+
+type EmailResponseError struct {
 	Code    string      `json:"code"`
 	Message string      `json:"message"`
 	Data    []EmailData `json:"data"`


### PR DESCRIPTION
(replaces previous PR)
Fix SendTemplateEmail error when the account is not activated yet for SMTP:
err sib.SendEmail : Could not decode response format: json: cannot unmarshal array into Go struct field EmailResponse.data of type sib.EmailData